### PR TITLE
Rstudio 2024a

### DIFF
--- a/apps/rstudio/form.yml.erb
+++ b/apps/rstudio/form.yml.erb
@@ -16,14 +16,8 @@ attributes:
     options:
       - ["2023a: RStudio-Server/2023.12.1+402 + R/4.3.2", "2023a"]
       - ["2022a: RStudio-Server/2022.07.2+576 + R/4.2.1", "2022a"]
-  r_bundle_cran:
-    label: "Load R-bundle-CRAN module for additional packages"
-    widget: "check_box"
-    checked_value: "yes"
-  r_bundle_bioconductor:
-    label: "Load R-bundle-Bioconductor module for additional packages"
-    widget: "check_box"
-    checked_value: "yes"
+    help: |
+      R-bundle-CRAN and R-bundle-Bioconductor are loaded by default.
   clean_workspace:
     label: "Clean workspace at startup"
     widget: "check_box"
@@ -34,8 +28,6 @@ attributes:
 form:
   - auto_queues
   - toolchain
-  - r_bundle_cran
-  - r_bundle_bioconductor
   - global_num_cores
   - bc_num_slots
   - global_bc_num_gpu_slots

--- a/apps/rstudio/form.yml.erb
+++ b/apps/rstudio/form.yml.erb
@@ -30,7 +30,6 @@ form:
   - auto_queues
   - toolchain
   - global_num_cores
-  - bc_num_slots
   - global_bc_num_gpu_slots
   - bc_num_hours
   - global_working_dir

--- a/apps/rstudio/form.yml.erb
+++ b/apps/rstudio/form.yml.erb
@@ -14,6 +14,7 @@ attributes:
     label: "Toolchain and R version"
     widget: "select"
     options:
+      - ["2024a: RStudio-Server/2024.12.0+467 + R/4.4.2", "2024a"]
       - ["2023a: RStudio-Server/2023.12.1+402 + R/4.3.2", "2023a"]
       - ["2022a: RStudio-Server/2022.07.2+576 + R/4.2.1", "2022a"]
     help: |

--- a/apps/rstudio/template/script.sh.erb
+++ b/apps/rstudio/template/script.sh.erb
@@ -12,21 +12,17 @@ if [[ -z "$XDG_DATA_HOME" ]]; then
 fi
 
 TOOLCHAIN=<%= context.toolchain %>
-R_BUNDLE_CRAN=<%= context.r_bundle_cran %>
-R_BUNDLE_BIOCONDUCTOR=<%= context.r_bundle_bioconductor %>
 
 modules_to_load=()
 
 case "${TOOLCHAIN}" in
   2022a )
     modules_to_load+=("RStudio-Server/2022.07.2+576-foss-2022a-Java-11-R-4.2.1")
-    # (there is no R-bundle-CRAN for 2022a, all packages are in the R module)
-    if [[ ${R_BUNDLE_BIOCONDUCTOR} == "yes" ]]; then modules_to_load+=("R-bundle-Bioconductor/3.15-foss-2022a-R-4.2.1"); fi
+    modules_to_load+=("R-bundle-Bioconductor/3.15-foss-2022a-R-4.2.1")
     ;;
   2023a )
     modules_to_load+=("RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2")
-    if [[ ${R_BUNDLE_CRAN} == "yes" ]]; then modules_to_load+=("R-bundle-CRAN/2023.12-foss-2023a"); fi
-    if [[ ${R_BUNDLE_BIOCONDUCTOR} == "yes" ]]; then modules_to_load+=("R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2"); fi
+    modules_to_load+=("R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2")
     ;;
   * )
     echo "ERROR: Unsupported toolchain selected"

--- a/apps/rstudio/template/script.sh.erb
+++ b/apps/rstudio/template/script.sh.erb
@@ -24,6 +24,10 @@ case "${TOOLCHAIN}" in
     modules_to_load+=("RStudio-Server/2023.12.1+402-gfbf-2023a-Java-11-R-4.3.2")
     modules_to_load+=("R-bundle-Bioconductor/3.18-foss-2023a-R-4.3.2")
     ;;
+  2024a )
+    modules_to_load+=("RStudio-Server/2024.12.0+467-foss-2024a-R-4.4.2")
+    modules_to_load+=("R-bundle-Bioconductor/3.20-foss-2024a-R-4.4.2")
+    ;;
   * )
     echo "ERROR: Unsupported toolchain selected"
     exit 1

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -3,7 +3,7 @@
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 1.27
+Version: 1.28
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -57,6 +57,8 @@ Scripts, customizations and tools for Open OnDemand as used at the VUB.
 /var/www/ood/apps/sys
 
 %changelog
+* Thu Jun 05 2025 Alex Domingo <alex.domingo.toro@vub.be>
+- Update Rstudio with 2024a environment and simplify its form
 * Fri May 23 2025 Ward Poelmans <ward.poelmans@vub.be>
 - Fix tmux option
 * Mon Apr 28 2025 Ward Poelmans <ward.poelmans@vub.be>


### PR DESCRIPTION
Fixes AD#24696 and AD#26005

Changelog:
* add 2024a environment for RStudio
* load R-bundle-CRAN and R-bundle-Bioconductor by default in all RStudio environments
* remove unused (and unuseful) option to increase number of nodes in RStudio