### PR TITLE
Update JupyterLab with 2024a environment and simplify its form

### DIFF
--- a/apps/jupyter-lab/form.yml.erb
+++ b/apps/jupyter-lab/form.yml.erb
@@ -17,16 +17,8 @@ attributes:
       - ["2024a: Python/3.12.3 + JupyterLab/4.2.5", "2024a"]
       - ["2023a: Python/3.11.3 + JupyterLab/4.2.1", "2023a"]
       - ["2022a: Python/3.10.4 + JupyterLab/3.5.0", "2022a"]
-  load_scipy:
-    label: "Load the SciPy-bundle module"
-    widget: "check_box"
-    checked_value: "yes"
-    unchecked_value: "no"
-  load_matplotlib:
-    label: "Load the matplotlib module (+ Lab extension)"
-    widget: "check_box"
-    checked_value: "yes"
-    unchecked_value: "no"
+    help: |
+      SciPy-bundle and matplotlib are loaded by default.
   load_dask:
     label: "Load the dask module (+ Lab extension)"
     widget: "check_box"
@@ -41,8 +33,6 @@ attributes:
 form:
   - auto_queues
   - toolchain
-  - load_scipy
-  - load_matplotlib
   - load_dask
   - load_molecules
   - global_num_cores

--- a/apps/jupyter-lab/template/script.sh.erb
+++ b/apps/jupyter-lab/template/script.sh.erb
@@ -60,8 +60,20 @@ if [[ -f "$USER_CONFIG_FILE" ]]; then
     cat "$USER_CONFIG_FILE" >> "${CONFIG_FILE}"
 fi
 
+jupyterlab_options=("-y")
+# avoid loading any local browser
+jupyterlab_options+=("--no-browser")
+# disable download of unreviewed extensions from the manager
+if [[ "${TOOLCHAIN}" =~ 202[34]a ]]; then
+    jupyterlab_options+=("--LabApp.extension_manager=readonly")
+fi
+# use our config files
+jupyterlab_options+=("--config=${CONFIG_FILE}")
+
 #
 # Start Jupyter Notebook Server
 #
 echo "TIMING - Starting jupyter at: $(date)"
-${EBROOTJUPYTERLAB}/bin/jupyter-lab -y --no-browser --config="${CONFIG_FILE}"
+jupyterlab_cmd="${EBROOTJUPYTERLAB}/bin/jupyter-lab ${jupyterlab_options[@]}"
+echo "Executing: $jupyterlab_cmd"
+$jupyterlab_cmd

--- a/apps/jupyter-lab/template/script.sh.erb
+++ b/apps/jupyter-lab/template/script.sh.erb
@@ -7,6 +7,13 @@ echo "TIMING - Starting main script at: $(date)"
 cd "$OOD_WD" || true
 
 TOOLCHAIN=<%= context.toolchain %>
+
+MODULES_DIR="/apps/brussel/${VSC_OS_LOCAL}/${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX:-}/modules"
+MODULES_TOOLCHAIN="${MODULES_DIR}/${TOOLCHAIN}/all"
+MODULES_SYSTEM="${MODULES_DIR}/system/all"
+export MODULEPATH="${MODULES_TOOLCHAIN}:${MODULES_SYSTEM}"
+echo "MODULEPATH set to: ${MODULEPATH}"
+
 LOAD_DASK=<%= context.load_dask %>
 LOAD_MOLECULES=<%= context.load_molecules %>
 
@@ -31,7 +38,7 @@ case "${TOOLCHAIN}" in
     modules_to_load+=("Jupyter-bundle/20250530-GCCcore-13.3.0")
     modules_to_load+=("SciPy-bundle/2024.05-gfbf-2024a")
     modules_to_load+=("ipympl/0.9.7-gfbf-2024a")
-    [[ "${LOAD_DASK}" == 'yes' ]] && modules_to_load+=("dask-labextension/7.0.0-foss-2024a" "xarray/2024.11.0-gfbf-2024a" "zarr/2.18.4-foss-2024a")
+    [[ "${LOAD_DASK}" == 'yes' ]] && modules_to_load+=("dask-labextension/7.0.0-gfbf-2024a" "xarray/2024.11.0-gfbf-2024a" "zarr/2.18.4-foss-2024a")
     [[ "${LOAD_MOLECULES}" == 'yes' ]] && modules_to_load+=("nglview/3.1.4-foss-2024a" "py3Dmol/2.5.0-GCCcore-13.3.0")
     ;;
   * )

--- a/apps/jupyter-lab/template/script.sh.erb
+++ b/apps/jupyter-lab/template/script.sh.erb
@@ -63,7 +63,7 @@ fi
 jupyterlab_options=("-y")
 # avoid loading any local browser
 jupyterlab_options+=("--no-browser")
-# disable download of unreviewed extensions from the manager
+# disable download of unreviewed extensions from the extension manager in JupyterLab 4
 if [[ "${TOOLCHAIN}" =~ 202[34]a ]]; then
     jupyterlab_options+=("--LabApp.extension_manager=readonly")
 fi

--- a/apps/jupyter-lab/template/script.sh.erb
+++ b/apps/jupyter-lab/template/script.sh.erb
@@ -7,8 +7,6 @@ echo "TIMING - Starting main script at: $(date)"
 cd "$OOD_WD" || true
 
 TOOLCHAIN=<%= context.toolchain %>
-LOAD_SCIPY=<%= context.load_scipy %>
-LOAD_MATPLOTLIB=<%= context.load_matplotlib %>
 LOAD_DASK=<%= context.load_dask %>
 LOAD_MOLECULES=<%= context.load_molecules %>
 
@@ -17,22 +15,22 @@ modules_to_load=()
 case "${TOOLCHAIN}" in
   2022a )
     modules_to_load+=("JupyterHub/3.1.1-GCCcore-11.3.0")
-    [[ "${LOAD_SCIPY}" == 'yes' ]] && modules_to_load+=("SciPy-bundle/2022.05-foss-2022a")
-    [[ "${LOAD_MATPLOTLIB}" == 'yes' ]] && modules_to_load+=("ipympl/0.9.3-foss-2022a")
+    modules_to_load+=("SciPy-bundle/2022.05-foss-2022a")
+    modules_to_load+=("ipympl/0.9.3-foss-2022a")
     [[ "${LOAD_DASK}" == 'yes' ]] && modules_to_load+=("dask-labextension/6.0.0-foss-2022a" "xarray/2022.6.0-foss-2022a" "zarr/2.13.3-foss-2022a")
     [[ "${LOAD_MOLECULES}" == 'yes' ]] && modules_to_load+=("nglview/3.0.3-foss-2022a" "py3Dmol/2.0.1.post1-GCCcore-11.3.0")
     ;;
   2023a )
     modules_to_load+=("Jupyter-bundle/20240522-GCCcore-12.3.0")
-    [[ "${LOAD_SCIPY}" == 'yes' ]] && modules_to_load+=("SciPy-bundle/2023.07-gfbf-2023a")
-    [[ "${LOAD_MATPLOTLIB}" == 'yes' ]] && modules_to_load+=("ipympl/0.9.4-gfbf-2023a")
+    modules_to_load+=("SciPy-bundle/2023.07-gfbf-2023a")
+    modules_to_load+=("ipympl/0.9.4-gfbf-2023a")
     [[ "${LOAD_DASK}" == 'yes' ]] && modules_to_load+=("dask-labextension/7.0.0-foss-2023a" "xarray/2023.9.0-gfbf-2023a" "zarr/2.17.1-foss-2023a")
     [[ "${LOAD_MOLECULES}" == 'yes' ]] && modules_to_load+=("nglview/3.1.2-foss-2023a" "py3Dmol/2.1.0-GCCcore-12.3.0")
     ;;
   2024a )
     modules_to_load+=("Jupyter-bundle/20250530-GCCcore-13.3.0")
-    [[ "${LOAD_SCIPY}" == 'yes' ]] && modules_to_load+=("SciPy-bundle/2024.05-gfbf-2024a")
-    [[ "${LOAD_MATPLOTLIB}" == 'yes' ]] && modules_to_load+=("ipympl/0.9.7-gfbf-2024a")
+    modules_to_load+=("SciPy-bundle/2024.05-gfbf-2024a")
+    modules_to_load+=("ipympl/0.9.7-gfbf-2024a")
     [[ "${LOAD_DASK}" == 'yes' ]] && modules_to_load+=("dask-labextension/7.0.0-foss-2024a" "xarray/2024.11.0-gfbf-2024a" "zarr/2.18.4-foss-2024a")
     [[ "${LOAD_MOLECULES}" == 'yes' ]] && modules_to_load+=("nglview/3.1.4-foss-2024a" "py3Dmol/2.5.0-GCCcore-13.3.0")
     ;;

--- a/apps/jupyter-lab/template/script.sh.erb
+++ b/apps/jupyter-lab/template/script.sh.erb
@@ -32,6 +32,9 @@ case "${TOOLCHAIN}" in
   2024a )
     modules_to_load+=("Jupyter-bundle/20250530-GCCcore-13.3.0")
     [[ "${LOAD_SCIPY}" == 'yes' ]] && modules_to_load+=("SciPy-bundle/2024.05-gfbf-2024a")
+    [[ "${LOAD_MATPLOTLIB}" == 'yes' ]] && modules_to_load+=("ipympl/0.9.7-gfbf-2024a")
+    [[ "${LOAD_DASK}" == 'yes' ]] && modules_to_load+=("dask-labextension/7.0.0-foss-2024a" "xarray/2024.11.0-gfbf-2024a" "zarr/2.18.4-foss-2024a")
+    [[ "${LOAD_MOLECULES}" == 'yes' ]] && modules_to_load+=("nglview/3.1.4-foss-2024a" "py3Dmol/2.5.0-GCCcore-13.3.0")
     ;;
   * )
     echo "ERROR: Unsupported toolchain selected"

--- a/apps/jupyter-lab/template/script.sh.erb
+++ b/apps/jupyter-lab/template/script.sh.erb
@@ -8,6 +8,8 @@ cd "$OOD_WD" || true
 
 TOOLCHAIN=<%= context.toolchain %>
 
+# restrict available modules to those that correspond to the same generation as the loaded JupyterLab
+# modules in other generations will fail to load and pollute the jupyterlmod panel
 MODULES_DIR="/apps/brussel/${VSC_OS_LOCAL}/${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX:-}/modules"
 MODULES_TOOLCHAIN="${MODULES_DIR}/${TOOLCHAIN}/all"
 MODULES_SYSTEM="${MODULES_DIR}/system/all"

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -3,7 +3,7 @@
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 1.28
+Version: 1.29
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -57,6 +57,8 @@ Scripts, customizations and tools for Open OnDemand as used at the VUB.
 /var/www/ood/apps/sys
 
 %changelog
+* Fri Jun 06 2025 Alex Domingo <alex.domingo.toro@vub.be>
+- Update JupyterLab with 2024a environment and simplify its form
 * Thu Jun 05 2025 Alex Domingo <alex.domingo.toro@vub.be>
 - Update Rstudio with 2024a environment and simplify its form
 * Fri May 23 2025 Ward Poelmans <ward.poelmans@vub.be>


### PR DESCRIPTION
Fixes AD#24695, AD#25891, AD#26034

Changelog:
* complete JupyterLab 2024a with missing options for Dask and Molecules
* load Scipy-bundle and matplotlib by default in JupyterLab
* restrict MODULEPATH in JupyterLab applications based on active toolchain
* disable extension manager in JupyterLab 4