### PR TITLE
Update ollama and stop Open WebUI from being launched with 0 shards

### DIFF
--- a/apps/open-webui/form.yml.erb
+++ b/apps/open-webui/form.yml.erb
@@ -35,6 +35,18 @@ attributes:
           data-hide-dynamic-num-gpu-slots: true,
           data-set-dynamic-num-gpu-slots: "",
         ]
+  # Block users from fetching 0 shards. Should not give any issues with gpu/shard item switching
+  # since Open WebUI cannot be run on Hydra.
+  bc_num_shards_no_0:
+    label: "Fraction of GPU to use"
+    help: 'Select how much of a GPU to use for the job.'
+    widget: "select"
+    value: "1"
+    options:
+      - ["25%", "1"]
+      - ["50%", "2"]
+      - ["75%", "3"]
+      - ["100%", "4"]
 
 form:
   - cluster
@@ -44,7 +56,7 @@ form:
   - bc_vnc_idle
   - global_num_cores
   - dynamic_num_gpu_slots
-  - global_bc_num_shards
+  - bc_num_shards_no_0
   - bc_num_hours_local
   - global_working_dir
   - global_prerun

--- a/apps/open-webui/form.yml.erb
+++ b/apps/open-webui/form.yml.erb
@@ -22,6 +22,7 @@ attributes:
     label: "Ollama version"
     widget: "select"
     options:
+      - ["2025a: ollama/0.15.6", "0.15.6"]
       - ["2025a: ollama/0.11.10", "0.11.10"]
       - ["2024a: ollama/0.5.12", "0.5.12"]
 <%= ERB.new(File.read(File.expand_path("../common_files/extra_attributes.yml.erb", __dir__)), eoutvar: "@common_attrs").result(binding) %>

--- a/apps/open-webui/submit.yml.erb
+++ b/apps/open-webui/submit.yml.erb
@@ -5,5 +5,6 @@ batch_connect:
 
 script:
   native:
+    <% global_bc_num_shards = bc_num_shards_no_0 %>
 <%= ERB.new(File.read(File.expand_path("../common_files/common_submit.yml.erb", __dir__)), eoutvar: "@common_submit").result(binding) %>
     - "--time=<%= bc_num_hours_local.to_i %>:00:00"

--- a/apps/open-webui/template/autostart.tmpl.sh
+++ b/apps/open-webui/template/autostart.tmpl.sh
@@ -16,6 +16,7 @@ echo 'Starting ollama...'
 export OLLAMA_HOST=0.0.0.0:$ollama_port
 export OLLAMA_MODELS="$OLLAMA_MODELS"
 export OLLAMA_NOPRUNE="true"
+export OLLAMA_NUM_THREADS=$SLURM_JOB_CPUS_PER_NODE
 ollama serve &>> "$OOD_SESSION_STAGED_ROOT/ollama-server.log" &
 ollama_pid=\$!
 

--- a/apps/open-webui/template/script.sh.erb
+++ b/apps/open-webui/template/script.sh.erb
@@ -16,6 +16,9 @@ case "${VERSION}" in
   0.11.10 )
     modules_to_load+=("ollama/0.11.10-GCCcore-14.2.0-CUDA-12.8.0")
     ;;
+  0.15.6 )
+    modules_to_load+=("ollama/0.15.6-GCCcore-14.2.0-CUDA-12.8.0")
+    ;;
   * )
     echo "ERROR: Unsupported version selected"
     exit 1
@@ -53,7 +56,9 @@ else
 fi
 
 # Substitute envionment variables into autostart.sh script
-envsubst '$MODULES_TO_LOAD,$OLLAMA_MODELS,$OPEN_WEBUI_DATA,$SLURM_JOB_ID,$OOD_SESSION_STAGED_ROOT,$DEFAULT_EMBEDDING_MODEL' \
+envsubst '$MODULES_TO_LOAD,$OLLAMA_MODELS,$OPEN_WEBUI_DATA,'\
+'$SLURM_JOB_ID,$SLURM_JOB_CPUS_PER_NODE,$OOD_SESSION_STAGED_ROOT,'\
+'$DEFAULT_EMBEDDING_MODEL' \
   <"$OOD_SESSION_STAGED_ROOT/autostart.tmpl.sh" \
   >"$OOD_SESSION_STAGED_ROOT/autostart.sh"
 

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -3,7 +3,7 @@
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.29
+Version: 2.30
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -61,6 +61,8 @@ Scripts, customizations and tools for Open OnDemand as used at the VUB.
 /var/www/ood/apps/sys
 
 %changelog
+* Thu Feb 24 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Add ollama 0.15.6, set OLLAMA_NUM_THREADS and remove 0 shard option from form
 * Thu Feb 12 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Add BioImage ANalysis app
 * Tue Feb 10 2026 Samuel Moors <samuel.moors@vub.be>


### PR DESCRIPTION
Add ollama 0.15.6 and set the OLLAMA_NUM_THREADS variable.

Also remove the 0% GPU option from the form. By default number of shards gets set to 0, but due to our setup, the OoD app just closes (since we require GPU to be present). This is confusing for users, so this no longer gives them the option. 