### PR TITLE
Fix automatic partition selection causing sbatch errors

### DIFF
--- a/apps/common_files/common_submit.yml.erb
+++ b/apps/common_files/common_submit.yml.erb
@@ -11,6 +11,6 @@
 <% if global_bc_num_shards.to_i > 0  %>
     - "--gres=shard:<%= global_bc_num_shards.to_i %>"
 <% end %>
-<% if auto_queues.to_s.strip.empty? %>
-  queue_name:
+<% if auto_queues.to_s.strip != "" %>
+    - "--partition=<%= auto_queues %>"
 <% end %>

--- a/apps/common_files/common_submit.yml.erb
+++ b/apps/common_files/common_submit.yml.erb
@@ -12,5 +12,6 @@
     - "--gres=shard:<%= global_bc_num_shards.to_i %>"
 <% end %>
 <% if auto_queues.to_s.strip.empty? %>
+  # WARNING: Don't add sbatch args after this template. When auto_queues is empty, YAML may treat them as queue_name.
   queue_name:
 <% end %>

--- a/apps/common_files/common_submit.yml.erb
+++ b/apps/common_files/common_submit.yml.erb
@@ -11,6 +11,6 @@
 <% if global_bc_num_shards.to_i > 0  %>
     - "--gres=shard:<%= global_bc_num_shards.to_i %>"
 <% end %>
-<% if auto_queues.to_s.strip != "" %>
+<% if ! auto_queues.to_s.strip.empty? %>
     - "--partition=<%= auto_queues %>"
 <% end %>

--- a/apps/common_files/common_submit.yml.erb
+++ b/apps/common_files/common_submit.yml.erb
@@ -11,6 +11,6 @@
 <% if global_bc_num_shards.to_i > 0  %>
     - "--gres=shard:<%= global_bc_num_shards.to_i %>"
 <% end %>
-<% if ! auto_queues.to_s.strip.empty? %>
-    - "--partition=<%= auto_queues %>"
+<% if auto_queues.to_s.strip.empty? %>
+  queue_name:
 <% end %>

--- a/apps/open-webui/submit.yml.erb
+++ b/apps/open-webui/submit.yml.erb
@@ -5,6 +5,6 @@ batch_connect:
 
 script:
   native:
-    <% global_bc_num_shards = bc_num_shards_no_0 %>
-<%= ERB.new(File.read(File.expand_path("../common_files/common_submit.yml.erb", __dir__)), eoutvar: "@common_submit").result(binding) %>
     - "--time=<%= bc_num_hours_local.to_i %>:00:00"
+<% global_bc_num_shards = bc_num_shards_no_0 %>
+<%= ERB.new(File.read(File.expand_path("../common_files/common_submit.yml.erb", __dir__)), eoutvar: "@common_submit").result(binding) %>

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -3,7 +3,7 @@
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.32
+Version: 2.33
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -61,6 +61,8 @@ Scripts, customizations and tools for Open OnDemand as used at the VUB.
 /var/www/ood/apps/sys
 
 %changelog
+* Tue Mar 11 2026 Cintia Willemyns <cintia.willemyns@vub.be>
+- Fix Open WebUI submission when using automatic partition selection
 * Fri Mar 06 2026 Bert Droesbeke <bert.droesbeke@vib.be>
 - Allow multiple Tensorboard jobs to be launched by the same user by fixing setCookie
 * Mon Mar 02 2026 Samuel Moors <samuel.moors@vub.be>


### PR DESCRIPTION
Fix sbatch partition flag when automatic partition is selected.

Only affects Open WebUI because it's the only app with arguments after the common template. When `auto_queues` is empty, the malformed queue_name: line causes YAML to interpret the following `--time` argument as its value, resulting in an sbatch error.

>sbatch: error: invalid partition specified: ["--time=4:00:00"]
sbatch: error: Batch job submission failed: Invalid partition name specified