### PR TITLE
Public beta - B-TXT-APPLICATIONS

### DIFF
--- a/apps/b-txt-applications/form.yml.erb
+++ b/apps/b-txt-applications/form.yml.erb
@@ -1,0 +1,79 @@
+---
+# app-specific attributes
+attributes:
+  bc_num_hours:
+    label: "Number of hours"
+    widget: "number_field"
+    value: 4
+    min: 1
+    step: 1
+  bc_vnc_idle: 0
+  bc_vnc_resolution:
+    required: true
+  desktop: 'xfce'
+  app_choice:
+    widget: 'select'
+    label: "App to launch"
+    options:
+      - [
+          'label-studio', 'label-studio',
+          data-set-global-num-cores: '16',
+          data-set-global-bc-num-shards: '0',
+          data-set-bc-num-hours: '2',
+        ]
+      - [
+          'portal', 'portal',
+          data-set-global-num-cores: '16',
+          data-set-global-bc-num-shards: '0',
+          data-set-bc-num-hours: '2',
+        ]
+  resolution:
+    widget: "select"
+    label: "Screen resolution"
+    options:
+      - ["FullHD (1920x1080)", "1920x1080"]
+      - ["HD (1280x720)", "1280x720"]
+<%= ERB.new(File.read(File.expand_path("../common_files/extra_attributes.yml.erb", __dir__)), eoutvar: "@common_attrs").result(binding) %>
+  cluster: 
+    widget: "select"
+    help: "B-TXT Applications can only be run on Anansi."
+    options: 
+      - [
+          'anansi', 'anansi',
+          data-hide-dynamic-num-gpu-slots: true,
+          data-set-dynamic-num-gpu-slots: "",
+        ]
+  global_advanced: # Override
+    widget: 'check_box'
+    label: "Show advanced options"
+    cacheable: true
+    html_options:
+      data:
+        hide-auto-queues-when-unchecked: true
+        hide-advanced-cleanup-login-when-unchecked: true
+        hide-advanced-font-size-when-unchecked: true
+        hide-advanced-tmux-config-when-unchecked: true
+        hide-global-advanced-num-nodes-when-unchecked: true
+        # Hide all fields behind advanced
+        hide-global-num-cores-when-unchecked: true
+        hide-global-bc-num-shards-when-unchecked: true
+        hide-global-working-dir-when-unchecked: true
+        hide-global-prerun-when-unchecked: true
+        hide-resolution-when-unchecked: true
+        hide-bc-num-hours-when-unchecked: true
+
+form:
+  - cluster
+  - desktop
+  - app_choice
+  - bc_vnc_idle
+  - bc_email_on_started
+  - global_advanced
+  - auto_queues
+  - resolution
+  - global_num_cores
+  - global_bc_num_shards
+  - bc_num_hours
+  - global_advanced_num_nodes
+  - global_working_dir
+  - global_prerun

--- a/apps/b-txt-applications/form.yml.erb
+++ b/apps/b-txt-applications/form.yml.erb
@@ -26,6 +26,7 @@ attributes:
           data-set-global-num-cores: '16',
           data-set-global-bc-num-shards: '0',
           data-set-bc-num-hours: '2',
+          data-hide-resolution: true
         ]
   resolution:
     widget: "select"

--- a/apps/b-txt-applications/manifest.yml
+++ b/apps/b-txt-applications/manifest.yml
@@ -1,0 +1,8 @@
+---
+name: B-TXT Applications
+category: Interactive Apps
+subcategory: Testing
+role: batch_connect
+description: |
+    Applications provided by the Brussels Digital Text Lab. These include tools to support researchers in the social sciences and humanities and beyond in the collection and analysis of digital, textual research data using AI and NLP techniques.
+    

--- a/apps/b-txt-applications/submit.yml.erb
+++ b/apps/b-txt-applications/submit.yml.erb
@@ -12,4 +12,5 @@ batch_connect:
 
 script:
   native:
+  # This line must always be last in the `native:` section
 <%= ERB.new(File.read(File.expand_path("../common_files/common_submit.yml.erb", __dir__)), eoutvar: "@common_submit").result(binding) %>

--- a/apps/b-txt-applications/submit.yml.erb
+++ b/apps/b-txt-applications/submit.yml.erb
@@ -1,0 +1,15 @@
+---
+# app_choice is env var exported in before.sh
+batch_connect:
+<%- if app_choice == 'label-studio' %>
+  template: vnc
+  geometry: "<%= resolution %>"
+<%- else %>
+  template: basic
+<%- end %>
+  conn_params:
+    - app_choice 
+
+script:
+  native:
+<%= ERB.new(File.read(File.expand_path("../common_files/common_submit.yml.erb", __dir__)), eoutvar: "@common_submit").result(binding) %>

--- a/apps/b-txt-applications/template/after.sh.erb
+++ b/apps/b-txt-applications/template/after.sh.erb
@@ -1,0 +1,17 @@
+export APP_CHOICE=<%= context.app_choice.to_s %>
+case "$APP_CHOICE" in
+  portal )
+    # Launch directly so do not wait
+    ;;
+  label-studio )
+    # Wait until Firefox has started
+    while ! pgrep -x firefox > /dev/null; do
+        sleep 1
+    done
+    echo "Firefox is up."
+    ;;
+  * )
+    echo "ERROR: Unsupported app chosen: $APP_CHOICE"
+    exit 1
+    ;;
+esac

--- a/apps/b-txt-applications/template/autostart.tmpl.sh
+++ b/apps/b-txt-applications/template/autostart.tmpl.sh
@@ -1,13 +1,6 @@
 mkdir -p $B_TXT_DATA
 
-# get free port - taken from https://stackoverflow.com/a/78125240
-local_app_port=15000
-
-while [ -n "$(ss -tan4H "sport = $local_app_port")" ]; do
-  local_app_port=$((port+1))
-done
-
-echo "Usable Port: $local_app_port"
+local_app_port=$(find_port)
 
 # APP_IMAGE is the path to image (should be in /apps/brussel/containers)
 case "$APP_CHOICE" in

--- a/apps/b-txt-applications/template/autostart.tmpl.sh
+++ b/apps/b-txt-applications/template/autostart.tmpl.sh
@@ -1,16 +1,22 @@
 mkdir -p $B_TXT_DATA
 
-# Optionally use private namespace (maybe with slirp4netns)
-# unshare -rn bash -eu <<EOF
-# ip link set lo up
+# get free port - taken from https://stackoverflow.com/a/78125240
+local_app_port=15000
+
+while [ -n "$(ss -tan4H "sport = $local_app_port")" ]; do
+  local_app_port=$((port+1))
+done
+
+echo "Usable Port: $local_app_port"
 
 # APP_IMAGE is the path to image (should be in /apps/brussel/containers)
 case "$APP_CHOICE" in
   label-studio )
     APP_IMAGE="/apps/brussel/containers/label-studio/label-studio.sif"
     apptainer run \
-      --env "WEBSERVER_PORT=$WEBSERVER_PORT" \
+      --env "WEBSERVER_PORT=${local_app_port}" \
       --bind $B_TXT_DATA:/app/data \
+      --contain \
       $APP_IMAGE &>> "$OOD_SESSION_STAGED_ROOT/label-studio.log" &
     app_pid=\$!
     URL_SUFFIX=""
@@ -23,15 +29,13 @@ case "$APP_CHOICE" in
 esac
 
 echo "Waiting for webserver to start..."
-until curl --output /dev/null --silent --head --fail http://localhost:$WEBSERVER_PORT; do
+until curl --output /dev/null --silent --head --fail http://localhost:${local_app_port}; do
     sleep 1
 done
 echo "$APP_CHOICE webserver is up."
 
 # Create new firefox profile and start new isolated instance with that profile
 firefox -CreateProfile "$SLURM_JOB_ID /tmp/ff-profile-$SLURM_JOB_ID"
-firefox -no-remote -P "$SLURM_JOB_ID" localhost:$WEBSERVER_PORT$URL_SUFFIX
+firefox -no-remote -P "$SLURM_JOB_ID" localhost:${local_app_port}$URL_SUFFIX
 
 [[ -n \$app_pid ]] && env kill --verbose \$app_pid
-
-#EOF 

--- a/apps/b-txt-applications/template/autostart.tmpl.sh
+++ b/apps/b-txt-applications/template/autostart.tmpl.sh
@@ -4,7 +4,7 @@ mkdir -p $B_TXT_DATA
 # unshare -rn bash -eu <<EOF
 # ip link set lo up
 
-# APP_IMAGE is the relative path to image from /apps/brussel/containers
+# APP_IMAGE is the path to image (should be in /apps/brussel/containers)
 case "$APP_CHOICE" in
   label-studio )
     APP_IMAGE="/apps/brussel/containers/label-studio/label-studio.sif"

--- a/apps/b-txt-applications/template/autostart.tmpl.sh
+++ b/apps/b-txt-applications/template/autostart.tmpl.sh
@@ -1,0 +1,37 @@
+mkdir -p $B_TXT_DATA
+
+# Optionally use private namespace (maybe with slirp4netns)
+# unshare -rn bash -eu <<EOF
+# ip link set lo up
+
+# APP_IMAGE is the relative path to image from /apps/brussel/containers
+case "$APP_CHOICE" in
+  label-studio )
+    APP_IMAGE="/apps/brussel/containers/label-studio/label-studio.sif"
+    apptainer run \
+      --env "WEBSERVER_PORT=$WEBSERVER_PORT" \
+      --bind $B_TXT_DATA:/app/data \
+      $APP_IMAGE &>> "$OOD_SESSION_STAGED_ROOT/label-studio.log" &
+    app_pid=\$!
+    URL_SUFFIX=""
+    ;;
+  * )
+    # If portal was chosen we should not launch the desktop
+    echo "ERROR: Unsupported app chosen: $APP_CHOICE"
+    exit 1
+    ;;
+esac
+
+echo "Waiting for webserver to start..."
+until curl --output /dev/null --silent --head --fail http://localhost:$WEBSERVER_PORT; do
+    sleep 1
+done
+echo "$APP_CHOICE webserver is up."
+
+# Create new firefox profile and start new isolated instance with that profile
+firefox -CreateProfile "$SLURM_JOB_ID /tmp/ff-profile-$SLURM_JOB_ID"
+firefox -no-remote -P "$SLURM_JOB_ID" localhost:$WEBSERVER_PORT$URL_SUFFIX
+
+[[ -n \$app_pid ]] && env kill --verbose \$app_pid
+
+#EOF 

--- a/apps/b-txt-applications/template/before.sh.erb
+++ b/apps/b-txt-applications/template/before.sh.erb
@@ -1,0 +1,8 @@
+<%= ERB.new(File.read('../common_files/ood_session.sh.erb'), eoutvar: 'child').result(binding) %>
+<%= ERB.new(File.read('../common_files/work_directory.sh.erb'), eoutvar: 'child').result(binding) %>
+<%= ERB.new(File.read('../common_files/job_environment.sh.erb'), eoutvar: 'child').result(binding) %>
+
+export OOD_APP_NAME="B-TXT Applications"
+
+# Gets used in view.html
+export app_choice=<%= context.app_choice.to_s %>

--- a/apps/b-txt-applications/template/script.sh.erb
+++ b/apps/b-txt-applications/template/script.sh.erb
@@ -1,0 +1,62 @@
+#!/usr/bin/bash -l
+
+<%= ERB.new(File.read('../common_files/work_directory_change.sh.erb'), eoutvar: 'child').result(binding) %>
+
+# Benchmark info
+echo "TIMING - Starting main script at: $(date)"
+
+export APP_CHOICE=<%= context.app_choice.to_s %>
+
+# In line with the advice from KUL docs we pick the port number
+# based on the VSC account number to ensure likelyhood that the
+# port is not yet in use ($USER looks like vsc11264).
+# If we put webserver with Firefox in namespace, this is not needed.
+export WEBSERVER_PORT=${USER:3}
+
+# Set VGL_DISPLAY to a GPU card if available, otherwise to Mesa llvmpipe
+<%= ERB.new(File.read('../common_files/oodegl.sh.erb'), eoutvar: 'child').result(binding) %>
+
+<%- unless context.global_prerun.empty? -%>
+<%= context.global_prerun.gsub("\r", "") %>
+<%- end -%>
+
+export B_TXT_DATA=${B_TXT_DATA:-$VSC_DATA/b-txt-data}/$APP_CHOICE
+
+mkdir -p $B_TXT_DATA
+
+# Substitute envionment variables into autostart.sh script
+envsubst '$APP_CHOICE,$B_TXT_DATA,$SLURM_JOB_ID,$WEBSERVER_PORT,$OOD_SESSION_STAGED_ROOT' \
+  <"$OOD_SESSION_STAGED_ROOT/autostart.tmpl.sh" \
+  >"$OOD_SESSION_STAGED_ROOT/autostart.sh"
+
+# Start up desktop or specific app
+# APP_IMAGE is the relative path to image from /apps/brussel/containers
+case "$APP_CHOICE" in
+
+  portal )
+    APP_IMAGE="/apps/brussel/containers/btxt-portal/btxt-portal.sif"
+
+    apptainer run --nv \
+<%- if context.global_bc_num_shards.to_i > 0 -%>
+      --env "LD_LIBRARY_PATH=$EBROOTCUDA:$LD_LIBRARY_PATH" \
+<%- end -%>
+      --env="WEBSERVER_PORT=${port}" \
+      --env="HOSTNAME=$HOSTNAME" \
+      --bind $B_TXT_DATA:/portal/resources/persisted \
+      $APP_IMAGE &>> "$OOD_SESSION_STAGED_ROOT/btxt-portal.log"
+    app_pid=\$!
+    ;;
+
+  label-studio )
+
+    echo "Launching desktop '<%= context.desktop %>'..."
+    <%= ERB.new(File.read("../common_files/desktops/#{context.desktop}.sh.erb"), eoutvar: 'child').result(binding) %>
+
+    echo "Desktop '<%= context.desktop %>' ended with $? status..."
+    ;;
+  * )
+    echo "ERROR: Unsupported app chosen: $APP_CHOICE"
+    exit 1
+    ;;
+esac
+

--- a/apps/b-txt-applications/template/script.sh.erb
+++ b/apps/b-txt-applications/template/script.sh.erb
@@ -7,12 +7,6 @@ echo "TIMING - Starting main script at: $(date)"
 
 export APP_CHOICE=<%= context.app_choice.to_s %>
 
-# In line with the advice from KUL docs we pick the port number
-# based on the VSC account number to ensure likelyhood that the
-# port is not yet in use ($USER looks like vsc11264).
-# If we put webserver with Firefox in namespace, this is not needed.
-export WEBSERVER_PORT=${USER:3}
-
 # Set VGL_DISPLAY to a GPU card if available, otherwise to Mesa llvmpipe
 <%= ERB.new(File.read('../common_files/oodegl.sh.erb'), eoutvar: 'child').result(binding) %>
 
@@ -25,7 +19,7 @@ export B_TXT_DATA=${B_TXT_DATA:-$VSC_DATA/b-txt-data}/$APP_CHOICE
 mkdir -p $B_TXT_DATA
 
 # Substitute envionment variables into autostart.sh script
-envsubst '$APP_CHOICE,$B_TXT_DATA,$SLURM_JOB_ID,$WEBSERVER_PORT,$OOD_SESSION_STAGED_ROOT' \
+envsubst '$APP_CHOICE,$B_TXT_DATA,$SLURM_JOB_ID,$OOD_SESSION_STAGED_ROOT,$port' \
   <"$OOD_SESSION_STAGED_ROOT/autostart.tmpl.sh" \
   >"$OOD_SESSION_STAGED_ROOT/autostart.sh"
 
@@ -37,11 +31,9 @@ case "$APP_CHOICE" in
     APP_IMAGE="/apps/brussel/containers/btxt-portal/btxt-portal.sif"
 
     apptainer run --nv \
-<%- if context.global_bc_num_shards.to_i > 0 -%>
-      --env "LD_LIBRARY_PATH=$EBROOTCUDA:$LD_LIBRARY_PATH" \
-<%- end -%>
       --env="WEBSERVER_PORT=${port}" \
       --env="HOSTNAME=$HOSTNAME" \
+      --contain \
       --bind $B_TXT_DATA:/portal/resources/persisted \
       $APP_IMAGE &>> "$OOD_SESSION_STAGED_ROOT/btxt-portal.log"
     app_pid=\$!

--- a/apps/b-txt-applications/view.html.erb
+++ b/apps/b-txt-applications/view.html.erb
@@ -1,6 +1,6 @@
 <%- if app_choice == "label-studio"  # remote desktop view for label studio -%>
 
-
+<%# Temporary copy paste from the VNC view, in future versions we should update this to include a reusable template to improve maintainability %>  
 <form role="form" action="/pun/sys/dashboard/noVNC-1.3.0/vnc.html" accept-charset="UTF-8" method="get">
  <input type="hidden" name="autoconnect" id="autoconnect" value="true" autocomplete="off">
  <input type="hidden" name="path" id="path" value="rnode/<%= host %>/<%= websocket %>/websockify" autocomplete="off">

--- a/apps/b-txt-applications/view.html.erb
+++ b/apps/b-txt-applications/view.html.erb
@@ -1,0 +1,43 @@
+<%- if app_choice == "label-studio"  # remote desktop view for label studio -%>
+
+
+<form role="form" action="/pun/sys/dashboard/noVNC-1.3.0/vnc.html" accept-charset="UTF-8" method="get">
+ <input type="hidden" name="autoconnect" id="autoconnect" value="true" autocomplete="off">
+ <input type="hidden" name="path" id="path" value="rnode/<%= host %>/<%= websocket %>/websockify" autocomplete="off">
+ <input type="hidden" name="resize" id="resize" value="remote" autocomplete="off">
+ <input type="hidden" name="password" id="password" value="<%= password %>" autocomplete="off">
+
+ <div class="row">
+  <div class="col-sm-6">
+   <div class="mb-3"><label class="form-label" for="compression">Compression</label><input class="form-control custom-range" type="range" min="1" max="9" value="6" name="compression" id="compression"><small class="form-text text-muted">1 (low) to 9 (high)</small></div>
+  </div>
+  <div class="col-sm-6">
+   <div class="mb-3"><label class="form-label" for="quality">Image Quality</label><input class="form-control custom-range" type="range" min="0" max="9" value="2" name="quality" id="quality"><small class="form-text text-muted">0 (low) to 9 (high)</small></div>
+  </div>
+ </div>
+
+  <script nonce="">
+//<![CDATA[
+    // Functions defined in batch_connect_sessions.js
+    for(var name of ['compression', 'quality']) {
+      tryUpdateSetting(name);
+      installSettingHandlers(name);
+    }
+
+//]]>
+</script>
+<input type="submit" name="commit" value="Launch <%= app_choice %>" class="btn btn-primary" formtarget="_blank" data-disable-with="Launch <%= app_choice %>">
+<a class="btn btn-light float-end border border-dark" target="_blank" href="/pun/sys/dashboard/noVNC-1.3.0/vnc.html?autoconnect=true&amp;password=<%= spassword %>&amp;path=rnode/<%= host %>/<%= websocket %>/websockify&amp;resize=downscale">View Only (Share-able Link)</a>
+</form>
+
+<%- else  # reverse proxy view -%>
+
+<form action="/node/<%= host %>/<%= port %>/" method="get" target="_blank">
+      <input type="hidden" name="file" value="Index.py"/>
+      <button class="btn btn-primary" type="submit">
+        <i class="fa fa-eye"></i> Connect to <%= app_choice %>
+      </button>
+</form>
+
+
+<%- end -%>

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -3,7 +3,7 @@
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.36
+Version: 2.37
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -61,6 +61,8 @@ Scripts, customizations and tools for Open OnDemand as used at the VUB.
 /var/www/ood/apps/sys
 
 %changelog
+* Wed Apr 29 2026 Yoshi Malaise <yoshi.kris.malaise@vub.be>
+- Added b-txt-applications interactive app for public beta testing.
 * Mon Mar 30 2026 Samuel Moors <samuel.moors@vub.be>
 - Update JupyterLab in 2025a to v4.5.6
 - Update dask-labextension in 2025a to use JupyterLab v4.5.6


### PR DESCRIPTION
Dear colleagues,

This pull request contains all files for the Interactive Apps provided by the B-TXT core facility.

With this release we aim to test the setup in a structured environment with all participants of the NLP course this Thursday at 10 am (as such the app is still marked for the Testing subcategory in the manifest). 

Feedback and insights gathered during this test will result in a revised version of the application that we aim to release on a future date together with appropriate training material and outreach.

The current setup contains 2 applications listed in the dropdown:

**Label Studio**: The label studio setup makes use of the VNC Desktop, it launches a label studio instance accessed via firefox, but it also launches an additional portal that can be used to download HF models and launch token classification / text classification ML backends compatible with label studio using python multiprocessing.

**Portal**: The portal application is a collection of smaller marimo notebooks that each contain the logic of small utilities used in the analysis of textual data. These utilities include tools for topics such as audio transcription, Named Entity Recognition,  Topic modelling, etc. These notebooks are tied together with a 'meta' layer that provides common components to ensure consistent navigation and ux experience as well as the sharing of HF models across the notebooks to prevent duplicate downloads. The portal application uses the /node reverse proxy to make the web app available from the browser of the user.

All applications are provided as Apptainer container images placed in /apps/brussel/containers/.
Upon first launch the applications will create a b-txt-data/<app> folder on the $VSC_DATA drive of the user to store all persisted files by mounting the folder on the container.

Since these are all interactive applications we only allow running them on Anansi.

This setup has been tested in the sandbox environment on the development environment of OoD 