### PR TITLE
Add ollama option to code-tunnel

### DIFF
--- a/apps/code-tunnel/form.yml.erb
+++ b/apps/code-tunnel/form.yml.erb
@@ -33,6 +33,29 @@ attributes:
         - Ensure your config file is compatible with Tmux 3.1b!
     widget: check_box
     value: "1"
+  use_ollama:
+    label: "Also serve Ollama in a private network namespace"
+    widget: check_box
+    value: "0"
+    html_options:
+      data:
+        hide-ollama-version-when-unchecked: true
+        hide-tunnel-auth-when-unchecked: true
+  ollama_version: # We only load CUDA versions
+    label: "Ollama version"
+    widget: "select"
+    help: "Needs a GPU otherwise the app terminates immediately."
+    options:
+      - ["2025a: ollama/0.15.6", "0.15.6"]
+      - ["2025a: ollama/0.11.10", "0.11.10"]
+      - ["2024a: ollama/0.5.12", "0.5.12"]
+  # Bit of a hack, TODO figure out how to interactively get this when using send-keys unshare
+  tunnel_auth: 
+    label: "Tunnel authentication method"
+    widget: "select"
+    options:
+      - 'GitHub'
+      - 'Microsoft'
 <%= ERB.new(File.read(File.expand_path("../common_files/extra_attributes.yml.erb", __dir__)), eoutvar: "@common_attrs").result(binding) %>
 
 form:
@@ -44,6 +67,9 @@ form:
   - global_working_dir
   - global_prerun
   - bc_email_on_started
+  - use_ollama
+  - tunnel_auth
+  - ollama_version
   - global_advanced
   - auto_queues
   - global_advanced_num_nodes

--- a/apps/code-tunnel/template/after.sh.erb
+++ b/apps/code-tunnel/template/after.sh.erb
@@ -2,3 +2,31 @@
 
 # wait for tmux socket and optional release of wait-for
 $OOD_SESSION_STAGED_ROOT/waitfor_tmux.sh
+
+if [[ $USE_OLLAMA -eq 1 ]]; then
+
+  # Wait until unshare has written its pid to ns.pid
+  while [ ! -s $OOD_SESSION_STAGED_ROOT/ns.pid ]; do sleep .1; done
+  UNSHARE_PID="$(cat $OOD_SESSION_STAGED_ROOT/ns.pid)"
+
+  echo "Starting network interface"
+
+  # This creates a tap0 device in the network namespace and provides a socket to configure
+  slirp4netns \
+    --configure \
+    --api-socket "$SLIRP_SOCKET" \
+    $UNSHARE_PID \
+    tap0 > "$OOD_SESSION_STAGED_ROOT/network.log" &
+
+  # now given network interface a second to boot
+  sleep 2
+
+  # now we've to to add the routing rule to the network
+  # This configures that $port in the host network namespace connects to port 80 inside the tensorboard namespace
+  echo "configuring network interface to use port $port"
+  SLIRP_CFG="{\"execute\": \"add_hostfwd\", \"arguments\": {\"proto\": \"tcp\", \"host_addr\": \"0.0.0.0\", \"host_port\": $port, \"guest_addr\": \"10.0.2.100\", \"guest_port\": 80}}"
+  echo -n "$SLIRP_CFG" | nc -U "$SLIRP_SOCKET"
+
+  echo "" # output from nc ^ doesn't end in a newline
+fi
+

--- a/apps/code-tunnel/template/before.sh.erb
+++ b/apps/code-tunnel/template/before.sh.erb
@@ -3,3 +3,25 @@
 <%= ERB.new(File.read('../common_files/job_environment.sh.erb'), eoutvar: 'child').result(binding) %>
 
 export OOD_APP_NAME="VS Code Tunnel"
+
+export USE_OLLAMA=<%= context.use_ollama %>
+
+if [[ $USE_OLLAMA -eq 1 ]]; then
+
+  if ! nvidia-smi >/dev/null 2>&1; then
+    echo No GPU detected, but Ollama option checked.
+    exit 1
+  fi
+
+  export OLLAMA_MODELS=${OLLAMA_MODELS:-"/databases/ollama"}
+
+  # slirp4netns complains about log socket names, so can't use session.staged_root
+  export SLIRP_SOCKET="$(mktemp)"
+
+
+  export OLLAMA_HOST=0.0.0.0:11434
+  export OLLAMA_MODELS=${OLLAMA_MODELS}
+  export OLLAMA_NOPRUNE="true"
+  export OLLAMA_NUM_THREADS=$SLURM_JOB_CPUS_PER_NODE
+
+fi

--- a/apps/code-tunnel/template/custom.sh.erb
+++ b/apps/code-tunnel/template/custom.sh.erb
@@ -8,7 +8,28 @@ for dir in .vscode .vscode-server; do
     fi
 done
 
-module load code-cli
+modules_to_load=("code-cli")
+
+if [[ $USE_OLLAMA -eq 1 ]]; then
+    ollama_version=<%= context.ollama_version%>
+    case "${ollama_version}" in
+      0.5.12 )
+        modules_to_load+=("ollama/0.5.12-GCCcore-13.3.0-CUDA-12.6.0")
+        ;;
+      0.11.10 )
+        modules_to_load+=("ollama/0.11.10-GCCcore-14.2.0-CUDA-12.8.0")
+        ;;
+      0.15.6 )
+        modules_to_load+=("ollama/0.15.6-GCCcore-14.2.0-CUDA-12.8.0")
+        ;;
+      * )
+        echo "ERROR: Unsupported version selected"
+        exit 1
+        ;;
+    esac
+fi
+
+module load "${modules_to_load[@]}"
 
 OOD_CONTEXT_CLEANUP_LOGIN=<%= context.advanced_cleanup_login %>
 

--- a/apps/code-tunnel/template/custom_commands.conf.erb
+++ b/apps/code-tunnel/template/custom_commands.conf.erb
@@ -3,4 +3,8 @@ reset
 echo
 echo "Copy the device code, open the url and paste it to create the tunnel vsc-$USER-$(hostname -d | sed 's/.os$//')"
 echo
+<% if context.use_ollama.to_s == '1' %>
+unshare -nr bash $OOD_SESSION_STAGED_ROOT/run_namespace.sh
+<% else %>
 code tunnel --accept-server-license-terms --name vsc-$USER-$(hostname -d | sed "s/.os$//")
+<% end %>

--- a/apps/code-tunnel/template/run_namespace.sh.erb
+++ b/apps/code-tunnel/template/run_namespace.sh.erb
@@ -1,0 +1,5 @@
+echo $$ > $OOD_SESSION_STAGED_ROOT/ns.pid
+code tunnel user login --provider <%= context.tunnel_auth.downcase %>
+code tunnel --accept-server-license-terms --name vsc-$USER-$(hostname -d | sed "s/.os$//") &
+ollama serve > $OOD_SESSION_STAGED_ROOT/ollama.log 2>&1 &
+exec bash

--- a/apps/code-tunnel/template/script.sh.erb
+++ b/apps/code-tunnel/template/script.sh.erb
@@ -2,3 +2,5 @@
 
 <%= ERB.new(File.read('../common_files/work_directory_change.sh.erb'), eoutvar: 'child').result(binding) %>
 <%= ERB.new(File.read('../common_files/launch_ttyd_tmux.sh.erb'), eoutvar: 'child').result(binding) %>
+
+


### PR DESCRIPTION
- [ ] Block access to hopper_gpu and ampere_gpu
- [ ] Handle better when ollama is selected without gpu
- [ ] Make sure the commands in the unshare script inside tmux can be run interactively (right now we need to ask auth method in the form when ollama is selected.)