### PR TITLE
Revert OOD_DATAROOT to use institute local

### DIFF
--- a/files/ood/profile
+++ b/files/ood/profile
@@ -16,9 +16,9 @@ if [ -n "$PUNUSER" ]; then
     eval "$(runuser -u "${PUNUSER}" -- python3 /usr/bin/vsc_env bash)"
 
     if [ -d "${VSC_DATA}" ]; then
-        export OOD_DATAROOT=${VSC_DATA}/.ondemand/${VSC_INSTITUTE_CLUSTER:-data}/
+        export OOD_DATAROOT=${VSC_DATA}/.ondemand/${VSC_INSTITUTE_LOCAL:-data}/
     else
-        export OOD_DATAROOT="${VSC_SCRATCH}/.ondemand/${VSC_INSTITUTE_CLUSTER:-data}/"
+        export OOD_DATAROOT="${VSC_SCRATCH}/.ondemand/${VSC_INSTITUTE_LOCAL:-data}/"
         logger -- "VSC_DATA unavailable for $PUNUSER, using OOD_DATAROOT: $OOD_DATAROOT"
     fi
 

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -3,7 +3,7 @@
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.42
+Version: 2.43
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -99,6 +99,8 @@ install -pm644 %{_datadir}/ondemand-vub/sofia/ondemand.d/general_options.yml \
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Tue Jun 23 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Revert OOD_DATAROOT to .ondemand/$VSC_INSTITUTE_LOCAL
 * Tue Jun 23 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Revert $HOME in profile script to $VSC_SCRATCH
 * Mon Jun 22 2026 Jarne Renders <jarne.thijs.renders@vub.be>


### PR DESCRIPTION
Do not change the location in Hydra. Safest to stick with institute on **sofia** as well in case of expansion in future.