### PR TITLE
Adapt submit options for sofia

### DIFF
--- a/apps/KasmVNC_desktop/form.yml.erb
+++ b/apps/KasmVNC_desktop/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -6,6 +7,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - global_num_cores
   - dynamic_num_gpu_slots
@@ -15,5 +20,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/KasmVNC_desktop/form.yml.erb
+++ b/apps/KasmVNC_desktop/form.yml.erb
@@ -8,7 +8,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/apps/abaqus/form.yml.erb
+++ b/apps/abaqus/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -28,6 +29,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - resolution
   - bc_vnc_idle
@@ -40,5 +45,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/abaqus/form.yml.erb
+++ b/apps/abaqus/form.yml.erb
@@ -30,7 +30,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/apps/b-txt-applications/form.yml.erb
+++ b/apps/b-txt-applications/form.yml.erb
@@ -67,7 +67,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/apps/b-txt-applications/form.yml.erb
+++ b/apps/b-txt-applications/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -65,12 +66,18 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - app_choice
   - bc_vnc_idle
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - resolution
   - global_num_cores
   - global_bc_num_shards

--- a/apps/bioimage_analysis_desktop/form.yml.erb
+++ b/apps/bioimage_analysis_desktop/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -15,6 +16,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - resolution
   - bc_vnc_idle
@@ -26,5 +31,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/bioimage_analysis_desktop/form.yml.erb
+++ b/apps/bioimage_analysis_desktop/form.yml.erb
@@ -17,7 +17,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/apps/code-server/form.yml.erb
+++ b/apps/code-server/form.yml.erb
@@ -7,7 +7,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - global_num_cores

--- a/apps/code-server/form.yml.erb
+++ b/apps/code-server/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -5,6 +6,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - global_num_cores
   - dynamic_num_gpu_slots
   - global_bc_num_shards
@@ -12,5 +17,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/code-tunnel/form.yml.erb
+++ b/apps/code-tunnel/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -31,6 +32,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - global_num_cores
   - dynamic_num_gpu_slots
   - global_bc_num_shards
@@ -39,7 +44,9 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes
   - advanced_font_size
   - advanced_tmux_config

--- a/apps/code-tunnel/form.yml.erb
+++ b/apps/code-tunnel/form.yml.erb
@@ -33,7 +33,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - global_num_cores

--- a/apps/common_files/common_submit.yml.erb
+++ b/apps/common_files/common_submit.yml.erb
@@ -1,3 +1,13 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
+<% sofia_gpu_partition = is_sofia && sofia_queues.to_s.match?(/_h\d+$/) %>
+<% # On sofia non-GPU partitions: one task per node, cores via --cpus-per-task. %>
+<% # GPU partitions skip CPU args entirely. %>
+<% if is_sofia && !sofia_gpu_partition %>
+    - "--nodes=<%= [global_advanced_num_nodes.to_i, 1].max %>"
+    - "--ntasks-per-node=1"
+    - "--cpus-per-task=<%= global_num_cores.to_i %>"
+<% # On Hydra: multi-node uses --ntasks, single-node uses --cpus-per-task %>
+<% elsif !is_sofia %>
 <% if global_advanced_num_nodes.to_i > 1 %>
     - "--nodes=<%= global_advanced_num_nodes.to_i %>"
     - "--ntasks=<%= global_num_cores.to_i %>"
@@ -5,13 +15,16 @@
     - "--cpus-per-task=<%= global_num_cores.to_i %>"
     - "--ntasks=1"
 <% end %>
+<% end %>
 <% if dynamic_num_gpu_slots.to_i > 0 %>
     - "--gpus-per-node=<%= dynamic_num_gpu_slots.to_i %>"
 <% end %>
 <% if global_bc_num_shards.to_i > 0  %>
     - "--gres=shard:<%= global_bc_num_shards.to_i %>"
 <% end %>
-<% if auto_queues.to_s.strip.empty? %>
+<% if is_sofia %>
+  queue_name: "<%= sofia_queues %>"
+<% elsif auto_queues.to_s.strip.empty? %>
   # WARNING: Don't add sbatch args after this template. When auto_queues is empty, YAML may treat them as queue_name.
   queue_name:
 <% end %>

--- a/apps/common_files/extra_attributes.yml.erb
+++ b/apps/common_files/extra_attributes.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
   cluster:
     widget: "select"
     options: <%
@@ -59,7 +60,9 @@
       - ["2", "2", <%= hide_for_non_gpu %>]
   auto_queues:
     label: "Partition"
+<% unless is_sofia %>
     include_blank: "automatic (recommended)"
     widget: "select"
     help: "Select <code>automatic</code> to request any eligible partition."
     value: ""
+<% end %>

--- a/apps/common_files/extra_attributes.yml.erb
+++ b/apps/common_files/extra_attributes.yml.erb
@@ -35,29 +35,35 @@
     help: "Select the total number of GPUs for the job."
     widget: "select"
     options: <%
-        # Get all partitions of all clusters
-        queues = SmartAttributes::AttributeFactory.send(:queues)
 
-        # Get gpu and non-gpu partitions (assumes gpu partitions end with 'gpu')
-        gpu_queues = queues.select { |label, _, _| label.to_s.end_with?('gpu') }.map { |label, _, _| label }
-        non_gpu_queues = queues.select { |label, _, _| !label.to_s.end_with?('gpu') }.map { |label, _, _| label }
+        # Fetch the partitions of all clusters defined in ood
+        partitions = SmartAttributes::AttributeFactory.send(:queues)
 
-        # Build a string of `data-option-for-auto-queues-*` attributes to hide all gpu partitions
-        hide_for_gpu = gpu_queues.map do |q|
-          q = q.to_s.gsub('_', '-')
-          "data-option-for-auto-queues-#{q}: false,"
-        end.join("\n")
+        supported_gpus = ->(partition_name) {
+          case partition_name.to_s
+          when /gpu$/    then 1..2 # gpu partitions on Hydra
+          when /_vis$/   then 0..2 # viz partition on sofia
+          when /_h\d+$/  then 1..8 # gpu partition on sofia
+          else                0..0
+          end
+        }
 
-        # Build a string of `data-option-for-auto-queues-*` attributes to hide all non-gpu partitions
-        hide_for_non_gpu = non_gpu_queues.map do |q|
-          q = q.to_s.gsub('_', '-')
-          "data-option-for-auto-queues-#{q}: false,"
-        end.join("\n")
+        # max_gpus will be 8 on sofia and 2 on Hydra
+        max_gpus = partitions.map { |name, _, _| supported_gpus.call(name).max }.max || 2
 
-        %>
-      - ["0", "0", <%= hide_for_gpu %>]
-      - ["1", "1", <%= hide_for_non_gpu %>]
-      - ["2", "2", <%= hide_for_non_gpu %>]
+        # Build select options ["gpu_count", "gpu_count", {hide attrs}] for each gpu_count 0..max_gpus.
+        # Partitions outside their supported range get a data-option-for-auto-queues-<name>: false
+        # attribute, which tells OOD to hide them from the partition dropdown at that gpu_count.
+        gpu_options = (0..max_gpus).map { |gpu_count|
+          hidden_partitions = {}
+          partitions.each do |name, _, _|
+            unless supported_gpus.call(name).include?(gpu_count)
+              hidden_partitions["data-option-for-auto-queues-#{name.to_s.gsub('_', '-')}"] = false
+            end
+          end
+          [gpu_count.to_s, gpu_count.to_s, hidden_partitions]
+        }
+    %><%= gpu_options.to_json %>
   auto_queues:
     label: "Partition"
 <% unless is_sofia %>

--- a/apps/common_files/extra_attributes.yml.erb
+++ b/apps/common_files/extra_attributes.yml.erb
@@ -34,8 +34,7 @@
       end
     %><%= cluster_opts.to_json %>
   dynamic_num_gpu_slots:
-    label: "Number of GPUs"
-    help: "Select the total number of GPUs per node for the job."
+    label: "Number of GPUs per node"
     widget: "select"
     options: <%
 

--- a/apps/common_files/extra_attributes.yml.erb
+++ b/apps/common_files/extra_attributes.yml.erb
@@ -1,6 +1,9 @@
 <% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
   cluster:
     widget: "select"
+<% if is_sofia %>
+    hide_by_default: true
+<% end %>
     options: <%
       cluster_options = SmartAttributes::AttributeFactory.send(:cluster_options)
 

--- a/apps/common_files/extra_attributes.yml.erb
+++ b/apps/common_files/extra_attributes.yml.erb
@@ -32,7 +32,7 @@
     %><%= cluster_opts.to_json %>
   dynamic_num_gpu_slots:
     label: "Number of GPUs"
-    help: "Select the total number of GPUs for the job."
+    help: "Select the total number of GPUs per node for the job."
     widget: "select"
     options: <%
 
@@ -42,7 +42,7 @@
         supported_gpus = ->(partition_name) {
           case partition_name.to_s
           when /gpu$/    then 1..2 # gpu partitions on Hydra
-          when /_vis$/   then 0..2 # viz partition on sofia
+          when /_vis$/   then 0..1 # viz partition on sofia, limit to 1 GPU
           when /_h\d+$/  then 1..8 # gpu partition on sofia
           else                0..0
           end
@@ -58,17 +58,34 @@
           hidden_partitions = {}
           partitions.each do |name, _, _|
             unless supported_gpus.call(name).include?(gpu_count)
-              hidden_partitions["data-option-for-auto-queues-#{name.to_s.gsub('_', '-')}"] = false
+              field = is_sofia ? "sofia-queues" : "auto-queues"
+              hidden_partitions["data-option-for-#{field}-#{name.to_s.gsub('_', '-')}"] = false
             end
           end
           [gpu_count.to_s, gpu_count.to_s, hidden_partitions]
         }
     %><%= gpu_options.to_json %>
+<% if is_sofia %>
+  sofia_queues:
+    label: "Partition"
+    widget: "select"
+    options: <%
+      partition_options = partitions.map do |name, value, data|
+        data = (data || {}).merge("data-set-global-num-cores" => "1")
+        data = data.merge("data-hide-global-num-cores" => true) if name.to_s.match?(/_h\d+$/)
+        if name.to_s.match?(/_vis$/)
+          data = data.merge("data-max-global-advanced-num-nodes" => 1, "data-set-global-advanced-num-nodes" => "1")
+        else
+          data = data.merge("data-max-global-advanced-num-nodes" => 16, "data-set-global-advanced-num-nodes" => "1")
+        end
+        [name, value, data]
+      end
+    %><%= partition_options.to_json %>
+<% else %>
   auto_queues:
     label: "Partition"
-<% unless is_sofia %>
-    include_blank: "automatic (recommended)"
     widget: "select"
+    include_blank: "automatic (recommended)"
     help: "Select <code>automatic</code> to request any eligible partition."
     value: ""
 <% end %>

--- a/apps/common_files/extra_attributes.yml.erb
+++ b/apps/common_files/extra_attributes.yml.erb
@@ -73,6 +73,12 @@
       partition_options = partitions.map do |name, value, data|
         data = (data || {}).merge("data-set-global-num-cores" => "1")
         data = data.merge("data-hide-global-num-cores" => true) if name.to_s.match?(/_h\d+$/)
+        max_cores = case name.to_s
+                    when /_dense$/ then 384
+                    when /_himem$/ then 192
+                    when /_vis$/   then 32
+                    end
+        data = data.merge("data-max-global-num-cores" => max_cores) if max_cores
         if name.to_s.match?(/_vis$/)
           data = data.merge("data-max-global-advanced-num-nodes" => 1, "data-set-global-advanced-num-nodes" => "1")
         else

--- a/apps/gaussview/form.yml.erb
+++ b/apps/gaussview/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -15,6 +16,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - resolution
   - bc_vnc_idle
@@ -26,5 +31,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/gaussview/form.yml.erb
+++ b/apps/gaussview/form.yml.erb
@@ -17,7 +17,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/apps/interactive-shell/form.yml.erb
+++ b/apps/interactive-shell/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -25,6 +26,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - global_num_cores
   - dynamic_num_gpu_slots
   - global_bc_num_shards
@@ -33,7 +38,9 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes
   - advanced_font_size
   - advanced_tmux_config

--- a/apps/interactive-shell/form.yml.erb
+++ b/apps/interactive-shell/form.yml.erb
@@ -27,7 +27,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - global_num_cores

--- a/apps/jupyter-lab/form.yml.erb
+++ b/apps/jupyter-lab/form.yml.erb
@@ -27,7 +27,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - toolchain

--- a/apps/jupyter-lab/form.yml.erb
+++ b/apps/jupyter-lab/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -25,6 +26,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - toolchain
   - load_dask
   - load_molecules
@@ -36,5 +41,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/matlab/form.yml.erb
+++ b/apps/matlab/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -13,6 +14,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - matlab_version
   - global_num_cores
   - dynamic_num_gpu_slots
@@ -22,5 +27,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/matlab/form.yml.erb
+++ b/apps/matlab/form.yml.erb
@@ -15,7 +15,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - matlab_version

--- a/apps/open-webui/form.yml.erb
+++ b/apps/open-webui/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -51,6 +52,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - ollama_version
   - resolution
@@ -63,5 +68,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/open-webui/form.yml.erb
+++ b/apps/open-webui/form.yml.erb
@@ -53,7 +53,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/apps/paraview/form.yml.erb
+++ b/apps/paraview/form.yml.erb
@@ -24,7 +24,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/apps/paraview/form.yml.erb
+++ b/apps/paraview/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -22,6 +23,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - toolchain
   - resolution
@@ -34,5 +39,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/rstudio/form.yml.erb
+++ b/apps/rstudio/form.yml.erb
@@ -24,7 +24,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - toolchain

--- a/apps/rstudio/form.yml.erb
+++ b/apps/rstudio/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -22,6 +23,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - toolchain
   - global_num_cores
   - dynamic_num_gpu_slots
@@ -32,5 +37,7 @@ form:
   - clean_workspace
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/slicer/form.yml.erb
+++ b/apps/slicer/form.yml.erb
@@ -22,7 +22,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/apps/slicer/form.yml.erb
+++ b/apps/slicer/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -20,6 +21,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - slicer_version
   - resolution
@@ -32,5 +37,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/tensorboard/form.yml.erb
+++ b/apps/tensorboard/form.yml.erb
@@ -18,7 +18,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - toolchain

--- a/apps/tensorboard/form.yml.erb
+++ b/apps/tensorboard/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -16,6 +17,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - toolchain
   - global_num_cores
   - dynamic_num_gpu_slots
@@ -25,5 +30,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/vub_desktop/form.yml.erb
+++ b/apps/vub_desktop/form.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 ---
 # app-specific attributes
 attributes:
@@ -15,6 +16,10 @@ attributes:
 
 form:
   - cluster
+<% if is_sofia %>
+  - auto_queues
+  - auto_accounts
+<% end %>
   - desktop
   - resolution
   - bc_vnc_idle
@@ -26,5 +31,7 @@ form:
   - global_prerun
   - bc_email_on_started
   - global_advanced
+<% unless is_sofia %>
   - auto_queues
+<% end %>
   - global_advanced_num_nodes

--- a/apps/vub_desktop/form.yml.erb
+++ b/apps/vub_desktop/form.yml.erb
@@ -17,7 +17,7 @@ attributes:
 form:
   - cluster
 <% if is_sofia %>
-  - auto_queues
+  - sofia_queues
   - auto_accounts
 <% end %>
   - desktop

--- a/files/ondemand.d/global_bc_items.yml.erb
+++ b/files/ondemand.d/global_bc_items.yml.erb
@@ -1,3 +1,4 @@
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 global_bc_form_items:
   bc_num_hours:
     label: "Number of hours"
@@ -32,7 +33,11 @@ global_bc_form_items:
     help: "Bash commands to be executed before starting the app"
   global_working_dir:
     label: Working Directory
+<% if is_sofia %>
+    help: "Optionally select your working directory (default: <code>$HOME</code>)."
+<% else %>
     help: "Optionally select your working directory (default: <code>$VSC_DATA</code>)."
+<% end %>
     widget: "path_selector"
     show_files: false
   global_advanced_num_nodes:
@@ -52,7 +57,9 @@ global_bc_form_items:
     cacheable: true
     html_options:
       data:
+<% unless is_sofia %>
         hide-auto-queues-when-unchecked: true
+<% end %>
         hide-advanced-cleanup-login-when-unchecked: true
         hide-advanced-font-size-when-unchecked: true
         hide-advanced-tmux-config-when-unchecked: true

--- a/files/ondemand.d/global_bc_items.yml.erb
+++ b/files/ondemand.d/global_bc_items.yml.erb
@@ -8,8 +8,7 @@ global_bc_form_items:
     step: 1
   global_num_cores:
     widget: "number_field"
-    label: "Number of cores"
-    help: 'Select the total number of CPU cores per node for the job.'
+    label: "Number of CPU cores per node"
     value: 1
     required: true
     min: 1

--- a/files/ondemand.d/global_bc_items.yml.erb
+++ b/files/ondemand.d/global_bc_items.yml.erb
@@ -57,9 +57,7 @@ global_bc_form_items:
     cacheable: true
     html_options:
       data:
-<% unless is_sofia %>
         hide-auto-queues-when-unchecked: true
-<% end %>
         hide-advanced-cleanup-login-when-unchecked: true
         hide-advanced-font-size-when-unchecked: true
         hide-advanced-tmux-config-when-unchecked: true

--- a/files/ood.rb
+++ b/files/ood.rb
@@ -22,5 +22,4 @@ Rails.application.config.after_initialize do
     # Project scratch is given an optional title field
     #"paths.concat projects.map { |p| FavoritePath.new("/fs/scratch/#{p}", title: "Scratch")  }
   end
-
 end

--- a/files/ood.rb
+++ b/files/ood.rb
@@ -22,4 +22,5 @@ Rails.application.config.after_initialize do
     # Project scratch is given an optional title field
     #"paths.concat projects.map { |p| FavoritePath.new("/fs/scratch/#{p}", title: "Scratch")  }
   end
+
 end

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -3,7 +3,7 @@
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.44
+Version: 2.45
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -54,7 +54,7 @@ Open OnDemand customizations for sofia
 %{__cp} -pr apps/* %{buildroot}%{_localstatedir}/www/ood/apps/sys/
 
 %{__mkdir_p} %{buildroot}%{_sysconfdir}/ood/config/ondemand.d
-%{__install} -pm644 ondemand.d/global_bc_items.yml %{buildroot}%{_sysconfdir}/ood/config/ondemand.d/
+%{__install} -pm644 ondemand.d/global_bc_items.yml.erb %{buildroot}%{_sysconfdir}/ood/config/ondemand.d/
 
 for cluster in hydra sofia; do
     install -Dpm644 locales/en.yml_$cluster \
@@ -71,7 +71,7 @@ done
 /etc/ood/config/apps/myjobs/templates
 /etc/ood/config/apps/dashboard/initializers/ood.rb
 /etc/ood/config/apps/dashboard/views/widgets/_news.html
-/etc/ood/config/ondemand.d/global_bc_items.yml
+/etc/ood/config/ondemand.d/global_bc_items.yml.erb
 /etc/ood/profile
 /var/www/ood/public
 /var/www/ood/apps/sys
@@ -99,6 +99,8 @@ install -pm644 %{_datadir}/ondemand-vub/sofia/ondemand.d/general_options.yml \
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Fri Jun 26 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Adapt common submission and form fields for sofia
 * Tue Jun 23 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Adapt vub-desktop to work on sofia (with xfce in container)
 * Tue Jun 23 2026 Jarne Renders <jarne.thijs.renders@vub.be>


### PR DESCRIPTION
This changes various things: 
1. In each form.yml.erb, we add - sofia_queues and - auto_accounts under - cluster. These will not show up in the Hydra generated yml. On **sofia**, the - auto_queues in the advanced section is hidden.
2. in common_submit, for **sofia** submit --nodes = X, --ntasks-per-node=1 and --cpus-per-task if we are not submitting in the GPU partition. (For that, the cpus get automatically set by the submit filter.) Also add here on **sofia** the queue_name option obtained via sofia_queues.
3. In extra_attributes, cleanup of the dynamic_num_gpu_slots field, but on Hydra behaviour should be the same. Add the sofia_queues field on sofia otherwise, adapt the auto_queues field for the automatic option. sofia_queues adds options so that when changing the partition, the form changes,
  * max nodes is 1 on vis, 16 on the other partitions
  * set max amount of cpus for dense and himem and set 32 for vis (not needed for h200)
  * hide the num_cores field when h200 partition is chosen
 Note that we cannot adapt the auto_queues field directly because the backend strips any additional options from that, hence sofia_queues.
4. Change global_bc_items.yml to .yml.erb and adapt helptext for the working dir field to point to $HOME vs $VSC_DATA on **sofia**, resp. Hydra.
5. On **sofia** hide the cluster field by default. So it does not show up redundantly. It still gets submitted with the form.

Many of these changes depend on:
`<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>`
This basically checks whether we have defined any clusters in `/etc/ood/config/clusters.d/` with name sofia. Hence, this should be able to detect whether we are on the sofia system or not without needing any (VSC) env vars. The clusters.d ymls are set by Quattor in Hydra and by Ansible in **sofia**.
 