### PR TITLE
Restrict py-2 style override

### DIFF
--- a/files/html/custom_styles.css_hydra
+++ b/files/html/custom_styles.css_hydra
@@ -109,7 +109,7 @@ h2, h3 {
 }
 
 /* increase dashboard logo size and center */
-.py-2 {
+img.py-2 {
   height: 5rem;
   margin-left: 16.6%;
 }

--- a/files/html/custom_styles.css_sofia
+++ b/files/html/custom_styles.css_sofia
@@ -111,7 +111,7 @@ h2, h3 {
 }
 
 /* increase dashboard logo size and center */
-.py-2 {
+img.py-2 {
   height: 5rem;
   margin-left: 16.6%;
 }

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.50
+Version: 2.51
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,6 +103,8 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Restrict py-2 style override to img tags
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Add D parameter to install for when directory does not exist
 * Wed Jul 01 2026 Jarne Renders <jarne.thijs.renders@vub.be>


### PR DESCRIPTION
The bars in the System Status app have too much left padding. This is because the `py-2` class style override in our custom style also has effect on this. The intention of overriding `py-2` is to center the main dashboard logo. 

Fix: only override `py-2` class when used in an image, i.e. `img.py-2`