### PR TITLE
Load oodegl.sh inside VNC container on sofia to fix vgl issue

### DIFF
--- a/apps/vub_desktop/template/script.sh.erb
+++ b/apps/vub_desktop/template/script.sh.erb
@@ -5,9 +5,6 @@
 # Benchmark info
 echo "TIMING - Starting main script at: $(date)"
 
-# Set VGL_DISPLAY to a GPU card if available, otherwise to Mesa llvmpipe
-<%= ERB.new(File.read('../common_files/oodegl.sh.erb'), eoutvar: 'child').result(binding) %>
-
 <%- unless context.global_prerun.empty? -%>
 <%= context.global_prerun.gsub("\r", "") %>
 <%- end -%>
@@ -23,9 +20,13 @@ if [ -e $xfce_container ]; then
         --bind /run/munge \
         $xfce_container \
         bash -s << 'END'
+# Set VGL_DISPLAY to a GPU card if available, otherwise to Mesa llvmpipe
+<%= ERB.new(File.read('../common_files/oodegl.sh.erb'), eoutvar: 'child').result(binding) %>
 <%= ERB.new(File.read("../common_files/desktops/#{context.desktop}.sh.erb"), eoutvar: 'child').result(binding) %>
 END
 else
+# Set VGL_DISPLAY to a GPU card if available, otherwise to Mesa llvmpipe
+<%= ERB.new(File.read('../common_files/oodegl.sh.erb'), eoutvar: 'child').result(binding) %>
 <%= ERB.new(File.read("../common_files/desktops/#{context.desktop}.sh.erb"), eoutvar: 'child').result(binding) %>
 fi
 

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.51
+Version: 2.52
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,6 +103,8 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Mon Jul 13 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Load oodegl.sh inside VNC container on sofia
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Restrict py-2 style override to img tags
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>


### PR DESCRIPTION
vglrun broke probably after reset of the ood vm on **sofia**, since egl stuff was installed on the host before. Now load the egl stuff inside the container.