### PR TITLE
Adapt rstudio, code-tunnel and code-server apps for sofia

### DIFF
--- a/apps/code-server/template/script.sh.erb
+++ b/apps/code-server/template/script.sh.erb
@@ -1,4 +1,6 @@
 #!/usr/bin/bash -l
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
+DATA_DIR="<%= is_sofia ? '$HOME' : '$VSC_DATA' %>"
 
 <%= ERB.new(File.read('../common_files/work_directory_change.sh.erb'), eoutvar: 'child').result(binding) %>
 
@@ -8,15 +10,17 @@ echo "TIMING - Starting main script at: $(date)"
 # Make symlinks for ~/.vscode and ~/.vscode-server
 for dir in .vscode .vscode-server; do
     if [[ ! -e ~/"$dir" ]]; then
-        mkdir -v -p "$VSC_DATA/$dir"
-        ln -v -s "$VSC_DATA/$dir" ~/"$dir"
+        mkdir -v -p "$DATA_DIR/$dir"
+<% unless is_sofia %>
+        ln -v -s "$DATA_DIR/$dir" ~/"$dir" # already at $HOME on sofia
+<% end %>
     fi
 done
 
 module load code-server
 
-extensions_dir="${VSC_DATA}/.config/code-server/extensions"
-data_dir="${VSC_DATA}/.config/code-server/data"
+extensions_dir="${DATA_DIR}/.config/code-server/extensions"
+data_dir="${DATA_DIR}/.config/code-server/data"
 
 mkdir -p "$extensions_dir"
 mkdir -p "$data_dir"

--- a/apps/code-tunnel/template/custom.sh.erb
+++ b/apps/code-tunnel/template/custom.sh.erb
@@ -2,6 +2,12 @@
 <% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 DATA_DIR="<%= is_sofia ? '$HOME' : '$VSC_DATA' %>"
 
+<% if is_sofia %>
+export TUNNEL_DOMAIN="sofia"
+<% else %>
+export TUNNEL_DOMAIN="$(hostname -d | sed 's/.os$//')"
+<% end %>
+
 # Make symlinks for ~/.vscode and ~/.vscode-server
 for dir in .vscode .vscode-server; do
     if [[ ! -e ~/"$dir" ]]; then

--- a/apps/code-tunnel/template/custom.sh.erb
+++ b/apps/code-tunnel/template/custom.sh.erb
@@ -2,12 +2,6 @@
 <% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 DATA_DIR="<%= is_sofia ? '$HOME' : '$VSC_DATA' %>"
 
-<% if is_sofia %>
-export TUNNEL_DOMAIN="sofia"
-<% else %>
-export TUNNEL_DOMAIN="$(hostname -d | sed 's/.os$//')"
-<% end %>
-
 # Make symlinks for ~/.vscode and ~/.vscode-server
 for dir in .vscode .vscode-server; do
     if [[ ! -e ~/"$dir" ]]; then

--- a/apps/code-tunnel/template/custom.sh.erb
+++ b/apps/code-tunnel/template/custom.sh.erb
@@ -1,10 +1,14 @@
 #!/bin/bash
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
+DATA_DIR="<%= is_sofia ? '$HOME' : '$VSC_DATA' %>"
 
 # Make symlinks for ~/.vscode and ~/.vscode-server
 for dir in .vscode .vscode-server; do
     if [[ ! -e ~/"$dir" ]]; then
-        mkdir -v -p "$VSC_DATA/$dir"
-        ln -v -s "$VSC_DATA/$dir" ~/"$dir"
+        mkdir -v -p "$DATA_DIR/$dir"
+<% unless is_sofia %>
+        ln -v -s "$DATA_DIR/$dir" ~/"$dir" # already at $HOME on sofia
+<% end %>
     fi
 done
 

--- a/apps/code-tunnel/template/custom.sh.erb
+++ b/apps/code-tunnel/template/custom.sh.erb
@@ -37,6 +37,7 @@ custom="$confdir/custom.conf"
 cat > $custom<<EOF
 new-session -d -s $TSES
 set -g status off #NOTE: this will disable the status bar (green text in the bottom)
+pipe-pane -o -t $TSES 'cat >> $OOD_SESSION_STAGED_ROOT/tunnel_session.log'
 EOF
 
 IFS=$'\n' # set the Internal Field Separator to newline

--- a/apps/code-tunnel/template/custom_commands.conf
+++ b/apps/code-tunnel/template/custom_commands.conf
@@ -1,6 +1,6 @@
 export VSCODE_CLI_USE_FILE_KEYCHAIN=1
 reset
 echo
-echo "Copy the device code, open the url and paste it to create the tunnel vsc-$USER-$TUNNEL_DOMAIN"
+echo "Copy the device code, open the url and paste it to create the tunnel vsc-$USER-$VSC_INSTITUTE_CLUSTER"
 echo
-code tunnel --accept-server-license-terms --name vsc-$USER-$TUNNEL_DOMAIN
+code tunnel --accept-server-license-terms --name vsc-$USER-$VSC_INSTITUTE_CLUSTER

--- a/apps/code-tunnel/template/custom_commands.conf
+++ b/apps/code-tunnel/template/custom_commands.conf
@@ -1,6 +1,6 @@
 export VSCODE_CLI_USE_FILE_KEYCHAIN=1
 reset
 echo
-echo "Copy the device code, open the url and paste it to create the tunnel vsc-$USER-$(hostname -d | sed 's/.os$//')"
+echo "Copy the device code, open the url and paste it to create the tunnel vsc-$USER-$TUNNEL_DOMAIN"
 echo
-code tunnel --accept-server-license-terms --name vsc-$USER-$(hostname -d | sed "s/.os$//")
+code tunnel --accept-server-license-terms --name vsc-$USER-$TUNNEL_DOMAIN

--- a/apps/rstudio/form.yml.erb
+++ b/apps/rstudio/form.yml.erb
@@ -7,9 +7,11 @@ attributes:
     widget: "select"
     options:
       - ["2025a: RStudio-Server/2025.09.2+418 + R/4.5.1", "2025a"]
+<% unless is_sofia %>
       - ["2024a: RStudio-Server/2024.12.0+467 + R/4.4.2", "2024a"]
       - ["2023a: RStudio-Server/2023.12.1+402 + R/4.3.2", "2023a"]
       - ["2022a: RStudio-Server/2022.07.2+576 + R/4.2.1", "2022a"]
+<% end %>
     help: |
       R-bundle-CRAN and R-bundle-Bioconductor are loaded by default.
   clean_workspace:

--- a/apps/rstudio/template/script.sh.erb
+++ b/apps/rstudio/template/script.sh.erb
@@ -1,5 +1,5 @@
 #!/usr/bin/bash -l
-
+<% is_sofia = OodAppkit.clusters.any? { |c| c.id.to_s == "sofia" } %>
 <%= ERB.new(File.read('../common_files/work_directory_change.sh.erb'), eoutvar: 'child').result(binding) %>
 
 # Benchmark info
@@ -7,7 +7,7 @@ echo "TIMING - Starting main script at: $(date)"
 
 # Set XDG_DATA_HOME to redirect the rstudio cache
 if [[ -z "$XDG_DATA_HOME" ]]; then
-    export XDG_DATA_HOME="$VSC_DATA/.local/share"
+    export XDG_DATA_HOME="<%= is_sofia ? '$HOME' : '$VSC_DATA' %>/.local/share"
     echo "setting XDG_DATA_HOME=$XDG_DATA_HOME"
 fi
 

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.51
+Version: 2.52
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,6 +103,8 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Mon Jul 13 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Load oodegl.sh inside VNC container on sofia
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Restrict py-2 style override to img tags
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.51
+Version: 2.52
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,6 +103,8 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Thu Jul 09 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Adapt code-tunnel app for sofia
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Restrict py-2 style override to img tags
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.51
+Version: 2.52
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,6 +103,8 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Thu Jul 09 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Adapt code-server app for sofia
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Restrict py-2 style override to img tags
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.52
+Version: 2.53
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,8 +103,10 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
-* Thu Jul 09 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+* Mon Jul 13 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Adapt code-server app for sofia
+* Mon Jul 13 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Load oodegl.sh inside VNC container on sofia
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Restrict py-2 style override to img tags
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.52
+Version: 2.53
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,8 +103,10 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
-* Thu Jul 09 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+* Mon Jul 13 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Adapt code-tunnel app for sofia
+* Mon Jul 13 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Load oodegl.sh inside VNC container on sofia
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Restrict py-2 style override to img tags
 * Mon Jul 06 2026 Jarne Renders <jarne.thijs.renders@vub.be>


### PR DESCRIPTION
Adapt the RStudio, code-tunnel and code-server apps for **sofia**.

Notable changes for code-tunnel:

* Now also writes the logs from the tmux session to a filed in the session dir. Makes it easier for debugging since the content of the tmux session was lost on app cancellation.
* The name of the tunnel session will contain `sofia` on **sofia**. Sticking with hostname -d, would simply give a hostname domain of host, which is not very enlightening.

Behaviour on Hydra is intended to be the unchanged except for the tmux logs splitting.