### PR TITLE
Improve sofia access denied msg

### DIFF
--- a/files/ood/profile_sofia
+++ b/files/ood/profile_sofia
@@ -15,8 +15,9 @@ if [ -n "$PUNUSER" ]; then
     # This only stops pun startup. Pre-existing puns should be cleaned in <2 hours via cron.
     logger -- "Checking whether $PUNUSER is in bsofia_projects and pun should be started"
     if [[ "$1" == "pun" ]] && ! id -Gn "$PUNUSER" 2>/dev/null | grep -qw 'bsofia_projects'; then
-        echo "Access denied: $PUNUSER is not authorized to use this system." >&2
-        echo "User $PUNUSER is not part of the bsofia_projects group." >&2
+        echo "Access denied: $PUNUSER is not a member of an active Tier-1 compute project on sofia." >&2
+        echo "Note that access to sofia is managed through the VSC hub, not the account.vscentrum.be account page." >&2
+        echo "See https://docs.vscentrum.be/brussel/tier1_sofia.html#getting-access for how to request or join a project." >&2
         echo "Please contact the support team (support@vscentrum.be) if you believe this is an error." >&2
         exit 1
     fi

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.53
+Version: 2.54
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,6 +103,8 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Thu Jul 16 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Improve sofia access denied message with VSC hub instructions
 * Mon Jul 13 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Adapt rstudio, code-tunnel and code-server apps for sofia
 - Add better logging for code-tunnel


### PR DESCRIPTION
Before the message indicated that user are not part of the bsofia_projects group. This indicated (especially for Hortense users) that the fix is to set this in the account page. Make clear one should go though the hub and link to the getting access page.