### PR TITLE
Add per-project favorite paths for T1 projects

### DIFF
--- a/files/ood.rb
+++ b/files/ood.rb
@@ -5,12 +5,21 @@ Rails.application.config.after_initialize do
     paths.clear()
 
     # add VSC paths
-    envs = ["VSC_DATA", "VSC_SCRATCH", "VSC_DATA_VO_USER", "VSC_SCRATCH_VO_USER", "VSC_DATA_VO", "VSC_SCRATCH_VO", "VSC_SCRATCH_PROJECTS_BASE"]
+    envs = ["VSC_DATA", "VSC_SCRATCH", "VSC_DATA_VO_USER", "VSC_SCRATCH_VO_USER", "VSC_DATA_VO", "VSC_SCRATCH_VO"]
 
     # If path exists and is not the same as $HOME, add it
     envs.each do |env|
       if (ENV.has_key?(env) && ENV[env] != ENV["HOME"])
         paths << FavoritePath.new(Pathname.new(ENV[env]), title: "#{env}")
+      end
+    end
+
+    # add an entry for each T1 project the user belongs to, e.g.
+    # VSC_T1_PROJECTS=2026_055:2026_056 -> "#{VSC_SCRATCH_PROJECTS_BASE}/2026_055", "#{VSC_SCRATCH_PROJECTS_BASE}/2026_056"
+    if ENV.has_key?("VSC_SCRATCH_PROJECTS_BASE") && ENV.has_key?("VSC_T1_PROJECTS")
+      projects_base = ENV["VSC_SCRATCH_PROJECTS_BASE"]
+      ENV["VSC_T1_PROJECTS"].split(":").each do |project|
+        paths << FavoritePath.new(Pathname.new("#{projects_base}/#{project}"), title: "Project #{project}")
       end
     end
 

--- a/files/ood.rb
+++ b/files/ood.rb
@@ -14,12 +14,11 @@ Rails.application.config.after_initialize do
       end
     end
 
-    # add an entry for each T1 project the user belongs to, e.g.
-    # VSC_T1_PROJECTS=2026_055:2026_056 -> "#{VSC_SCRATCH_PROJECTS_BASE}/2026_055", "#{VSC_SCRATCH_PROJECTS_BASE}/2026_056"
-    if ENV.has_key?("VSC_SCRATCH_PROJECTS_BASE") && ENV.has_key?("VSC_T1_PROJECTS")
-      projects_base = ENV["VSC_SCRATCH_PROJECTS_BASE"]
+    # add an entry for each Tier-1 project the user belongs to on sofia, e.g.
+    # VSC_T1_PROJECTS=2026_055:2026_056 -> "/sofia/projects/2026_055", "/sofia/projects/2026_056"
+    if ENV.has_key?("VSC_T1_PROJECTS")
       ENV["VSC_T1_PROJECTS"].split(":").each do |project|
-        paths << FavoritePath.new(Pathname.new("#{projects_base}/#{project}"), title: "Project #{project}")
+        paths << FavoritePath.new(Pathname.new("/sofia/projects/#{project}"), title: "Project #{project}")
       end
     end
 

--- a/files/ood/profile_sofia
+++ b/files/ood/profile_sofia
@@ -28,4 +28,25 @@ if [ -n "$PUNUSER" ]; then
     export OOD_DATAROOT="${VSC_SCRATCH}/.ondemand/${VSC_INSTITUTE_LOCAL:-data}/"
 
     runuser -u "${PUNUSER}" bash /etc/profile.d/vscautokey.sh &
+
+    # Single source of truth for the naming scheme:
+    VSC_T1_GROUP_PREFIX=bsofia_proj_
+
+    # id -nG lists all group names of the current user, space separated.
+    # sed -n 's/^prefix//p' both filters and strips in one pass.
+    # paste joins with ':'.
+    VSC_T1_PROJECTS=$(id -nG ${PUNUSER} \
+        | tr ' ' '\n' \
+        | sed -n "s/^${VSC_T1_GROUP_PREFIX}//p" \
+        | sort \
+        | paste -sd: -)
+
+    # Only export when the user actually has Tier-1 projects, so scripts can
+    # test with [ -n "$VSC_T1_PROJECTS" ] instead of distinguishing empty vs unset.
+    if [ -n "$VSC_T1_PROJECTS" ]; then
+        export VSC_T1_PROJECTS
+    else
+        unset VSC_T1_PROJECTS
+    fi
+    unset VSC_T1_GROUP_PREFIX
 fi

--- a/ondemand-vub.spec
+++ b/ondemand-vub.spec
@@ -10,7 +10,7 @@ install -Dpm644 %{_datadir}/ondemand-vub/%1/ondemand.d/general_options.yml %{_sy
 
 Summary: Scripts, customizations and tools for Open OnDemand
 Name: ondemand-vub
-Version: 2.55
+Version: 2.56
 Release: 1
 BuildArch: noarch
 License: GPL
@@ -103,6 +103,8 @@ chmod 0750 %{_localstatedir}/www/ood/apps/sys/abaqus
 chmod 0000 %{_localstatedir}/www/ood/apps/sys/abaqus
 
 %changelog
+* Mon Aug 03 2026 Jarne Renders <jarne.thijs.renders@vub.be>
+- Export VSC_T1_PROJECTS in sofia profile and add per-project favorite paths in Files app
 * Thu Jul 16 2026 Jarne Renders <jarne.thijs.renders@vub.be>
 - Adapt slicer app for sofia
 * Thu Jul 16 2026 Jarne Renders <jarne.thijs.renders@vub.be>


### PR DESCRIPTION
We create the VSC_T1_PROJECTS env var based on the unix groups the punuser is part of. That variable will only be visible in the pun. 

Ideally, that is provided by a vsc package, but this might still be blocked for a long time, hence the code is ported to bash and executed by profile_sofia.

Has no visible effect on Hydra since VSC_T1_PROJECTS does not exist and if it would, the paths are not present on that filesystem.

Tested on **sofia**: When VSC_T1_PROJECTS does not exist, nothing happens. If path is not readable by user, it is not visible in the list in the file explorer.